### PR TITLE
Update to use JustTweak 4

### DIFF
--- a/AutomationTools.podspec
+++ b/AutomationTools.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'AutomationTools'
-  s.version          = '1.0.0'
+  s.version          = '1.1.0'
   s.summary          = 'iOS UI test framework and guidelines'
   s.homepage         = 'https://github.com/justeat/AutomationTools'
   s.license          = { :type => 'Apache 2.0', :file => 'LICENSE' }

--- a/AutomationTools/Classes/Core/Extensions/ExtensionXCUIApplication.swift
+++ b/AutomationTools/Classes/Core/Extensions/ExtensionXCUIApplication.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import XCTest
+import JustTweak
 
 public struct Flag {
     public let key: String
@@ -27,15 +28,9 @@ extension XCUIApplication {
         for flag in featureFlags {
             let key = flag.key
             let value = flag.value
-            // this check on the class is 'unfortunately' necessary to do here if
-            // we want to allow a nicer way to pass flags from the UI Tests
             switch value {
-            case is Bool:
-                ephemeralConfiguration.set(value as! Bool, feature: "", variable: key)
-            case is String:
-                ephemeralConfiguration.set(value as! String, feature: "", variable: key)
-            case is NSNumber:
-                ephemeralConfiguration.set(value as! NSNumber, feature: "", variable: key)
+            case is TweakValue:
+                ephemeralConfiguration.set(value as! TweakValue, feature: "", variable: key)
             default: ()
             }
         }
@@ -45,17 +40,9 @@ extension XCUIApplication {
         for flag in automationFlags {
             let key = flag.key
             let value = flag.value
-            // this check on the class is 'unfortunately' necessary to do here if
-            // we want to allow a nicer way to pass flags from the UI Tests
             switch value {
-            case is Bool:
-                automationConfiguration[key] = NSNumber(value: value as! Bool)
-            case is Int:
-                automationConfiguration[key] = NSNumber(value: value as! Int)
-            case is String:
-                automationConfiguration[key] = value
-            case is NSNumber:
-                automationConfiguration[key] = value
+            case is TweakValue:
+                automationConfiguration[key] = value as! TweakValue
             default: ()
             }
         }

--- a/AutomationTools/Classes/Shared/NSMutableDictionary+MutableTweaksConfiguration.swift
+++ b/AutomationTools/Classes/Shared/NSMutableDictionary+MutableTweaksConfiguration.swift
@@ -42,15 +42,7 @@ extension NSMutableDictionary: MutableTweaksConfiguration {
         removeObject(forKey: variable)
     }
     
-    public func set(_ value: Bool, feature: String, variable: String) {
-        self[variable] = NSNumber(value: value)
-    }
-    
-    public func set(_ value: String, feature: String, variable: String) {
-        self[variable] = value
-    }
-    
-    public func set(_ value: NSNumber, feature: String, variable: String) {
+    public func set(_ value: TweakValue, feature: String, variable: String) {
         self[variable] = value
     }
 }

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -4,10 +4,10 @@ platform :ios, '11.0'
 
 target 'AutomationTools_Example' do
   pod 'AutomationTools/HostApp', :path => '../'
-  
+  pod 'JustTweak', '~> 4.0.0'
 end
 
 target 'AutomationTools_UITests' do
   pod 'AutomationTools/Core', :path => '../'
-    
+  pod 'JustTweak', '~> 4.0.0'
 end

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,18 +1,19 @@
 PODS:
-  - AutomationTools/Core (1.0.0):
+  - AutomationTools/Core (1.1.0):
     - JustTweak
-  - AutomationTools/HostApp (1.0.0):
+  - AutomationTools/HostApp (1.1.0):
     - JustTweak
-  - JustTweak (3.5.0):
-    - JustTweak/Core (= 3.5.0)
-    - JustTweak/UI (= 3.5.0)
-  - JustTweak/Core (3.5.0)
-  - JustTweak/UI (3.5.0):
+  - JustTweak (4.0.0):
+    - JustTweak/Core (= 4.0.0)
+    - JustTweak/UI (= 4.0.0)
+  - JustTweak/Core (4.0.0)
+  - JustTweak/UI (4.0.0):
     - JustTweak/Core
 
 DEPENDENCIES:
   - AutomationTools/Core (from `../`)
   - AutomationTools/HostApp (from `../`)
+  - JustTweak (= 4.0.0)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
@@ -23,9 +24,9 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  AutomationTools: c5230669de7a76d6e4e4eb2dd720c15c9bdb5b48
-  JustTweak: 01cf18b06845c30ecac27c123f2d30f89eece01c
+  AutomationTools: bec0bb028c4fba543de6ab818dc59786adf28e65
+  JustTweak: 3edc6464d63601037a507571c6efa27a55d75988
 
-PODFILE CHECKSUM: 17186affbdbcd4414b3f284b097accf2537e53da
+PODFILE CHECKSUM: b1f1ca5a679f1f82586e34ea188cb6036552c64b
 
 COCOAPODS: 1.6.2


### PR DESCRIPTION
This PR updates the dependency to JustTweak version 4.
Leaving the version unset in the podspec, but pinning the version to 4.0.0 using the optimistic operator in the demo app's Podfile.