### PR TITLE
Skip unnecessary wait

### DIFF
--- a/AutomationTools.podspec
+++ b/AutomationTools.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'AutomationTools'
-  s.version          = '4.0.0'
+  s.version          = '4.1.0'
   s.summary          = 'iOS UI test framework and guidelines'
   s.homepage         = 'https://github.com/justeat/AutomationTools'
   s.license          = { :type => 'Apache 2.0', :file => 'LICENSE' }

--- a/AutomationTools/Classes/Core/Extensions/ExtensionXCTestCase.swift
+++ b/AutomationTools/Classes/Core/Extensions/ExtensionXCTestCase.swift
@@ -8,32 +8,65 @@
 
 import XCTest
 
+/// This function immediately return if the initial condition is true and must wait is set to false. The idea is that usually we check for existence since testing non existence
+/// is trickier.
+func evaluate(condition: () -> Bool, shouldProceed proceedCondition: @autoclosure () -> Bool, mustWait: Bool) -> Bool {
+    if !mustWait && proceedCondition() { return true }
+    return condition()
+}
+
+func waitIfNeeded(_ block: () -> Void, shouldProceed proceedCondition: @autoclosure () -> Bool, mustWait: Bool) {
+    if !mustWait && proceedCondition() { return }
+    block()
+}
+
 extension XCTestCase {
     
-    public func waitForElementToNotExist(element: XCUIElement, timeout: Double = 10) {
-        expectation(for: NSPredicate(format: "exists == false"), evaluatedWith: element, handler: nil)
-        waitForExpectations(timeout: timeout, handler: nil)
+    public func waitForElementToNotExist(element: XCUIElement, timeout: Double = 10, mustWait: Bool = false) {
+        waitIfNeeded({
+            expectation(for: NSPredicate(format: "exists == false"), evaluatedWith: element, handler: nil)
+            waitForExpectations(timeout: timeout, handler: nil)
+        },
+                     shouldProceed: !element.exists,
+                     mustWait: mustWait)
     }
     
-    public func waitForElementToExist(element: XCUIElement, timeout: Double = 10) {
-        expectation(for: NSPredicate(format: "exists == true"), evaluatedWith: element, handler: nil)
-        waitForExpectations(timeout: timeout, handler: nil)
+    public func waitForElementToExist(element: XCUIElement, timeout: Double = 10, mustWait: Bool = false) {
+        waitIfNeeded({
+            expectation(for: NSPredicate(format: "exists == true"), evaluatedWith: element, handler: nil)
+            waitForExpectations(timeout: timeout, handler: nil)
+        },
+                     shouldProceed: element.exists,
+                     mustWait: mustWait)
     }
     
-    public func waitForElementValueToExist(element: XCUIElement, valueString: String, timeout: Double = 10) {
-        expectation(for: NSPredicate(format: "value == \(valueString)"), evaluatedWith: element, handler: nil)
-        waitForExpectations(timeout: timeout, handler: nil)
+    public func waitForElementValueToExist(element: XCUIElement, valueString: String, timeout: Double = 10, mustWait: Bool = false) {
+        let value = element.value as? String
+        waitIfNeeded({
+            expectation(for: NSPredicate(format: "value == \(valueString)"), evaluatedWith: element, handler: nil)
+            waitForExpectations(timeout: timeout, handler: nil)
+        },
+                     shouldProceed: value == valueString,
+                     mustWait: mustWait)
     }
     
-    public func waitForElementToBeHittable(element: XCUIElement, timeout: Double = 10) {
-        waitForElementToExist(element: element, timeout: timeout)
-        expectation(for: NSPredicate(format: "isHittable == true"), evaluatedWith: element, handler: nil)
-        waitForExpectations(timeout: 2, handler: nil)
+    public func waitForElementToBeHittable(element: XCUIElement, timeout: Double = 10, mustWait: Bool = false) {
+        waitIfNeeded({
+            waitForElementToExist(element: element, timeout: timeout)
+            expectation(for: NSPredicate(format: "isHittable == true"), evaluatedWith: element, handler: nil)
+            waitForExpectations(timeout: 2, handler: nil)
+        },
+                     shouldProceed: element.isHittable,
+                     mustWait: mustWait)
     }
     
-    public func waitForElementToBeEnabled(element: XCUIElement, timeout: Double = 10) {
-        waitForElementToExist(element: element, timeout: timeout)
-        expectation(for: NSPredicate(format: "isEnabled == true"), evaluatedWith: element, handler: nil)
-        waitForExpectations(timeout: 20, handler: nil)
+    public func waitForElementToBeEnabled(element: XCUIElement, timeout: Double = 10, mustWait: Bool = false) {
+        waitIfNeeded({
+            waitForElementToExist(element: element, timeout: timeout)
+            expectation(for: NSPredicate(format: "isEnabled == true"), evaluatedWith: element, handler: nil)
+            waitForExpectations(timeout: 20, handler: nil)
+        },
+                     shouldProceed: element.isEnabled,
+                     mustWait: mustWait)
     }
 }


### PR DESCRIPTION
This PR improves tests speed by removing the wait if the elements the tests are waiting for are already existing. 