### PR TITLE
Version 5.0.0. Turn subspecs into 2 separate podspecs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,5 @@ language: swift
 script:
 - travis_wait 30 bundle exec pod install --repo-update --project-directory=Example
 - set -o pipefail && xcodebuild test -enableCodeCoverage YES -workspace Example/AutomationTools.xcworkspace -scheme AutomationTools-Example ONLY_ACTIVE_ARCH=NO -destination 'platform=iOS Simulator,OS=13.1,name=iPhone 11'
-- bundle exec pod lib lint --allow-warnings
+- bundle exec pod lib lint AutomationTools-Core.podspec --allow-warnings
+- bundle exec pod lib lint AutomationTools-Host.podspec --allow-warnings

--- a/AutomationTools-Core.podspec
+++ b/AutomationTools-Core.podspec
@@ -1,0 +1,19 @@
+Pod::Spec.new do |s|
+  s.name             = 'AutomationTools-Core'
+  s.version          = '5.0.0'
+  s.summary          = 'iOS UI test framework and guidelines'
+  s.homepage         = 'https://github.com/justeat/AutomationTools'
+  s.license          = { :type => 'Apache 2.0', :file => 'LICENSE' }
+  s.author           = { 'Alberto De Bortoli' => 'alberto.debortoli@just-eat.com',
+                         'Sneha Narayana Swamy' => 'sneha.narayanaswamy@just-eat.com' }
+  s.source           = { :git => 'https://github.com/justeat/AutomationTools.git', :tag => s.version.to_s }
+
+  s.ios.deployment_target = '11.0'
+  s.swift_version = '5.0'
+  
+  s.subspec 'Core' do |ss|
+    ss.ios.source_files = ['AutomationTools/Classes/Core/**/*']
+    ss.ios.frameworks = ['Foundation', 'XCTest']
+  end
+  
+end

--- a/AutomationTools-Host.podspec
+++ b/AutomationTools-Host.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
-  s.name             = 'AutomationTools'
-  s.version          = '4.1.1'
+  s.name             = 'AutomationTools-Host'
+  s.version          = '5.0.0'
   s.summary          = 'iOS UI test framework and guidelines'
   s.homepage         = 'https://github.com/justeat/AutomationTools'
   s.license          = { :type => 'Apache 2.0', :file => 'LICENSE' }
@@ -11,13 +11,8 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '11.0'
   s.swift_version = '5.0'
   
-  s.subspec 'HostApp' do |ss|
-      ss.ios.source_files = ['AutomationTools/Classes/HostApp/**/*']
-  end
-  
-  s.subspec 'Core' do |ss|
-      ss.ios.source_files = ['AutomationTools/Classes/Core/**/*']
-      ss.ios.frameworks = ['Foundation', 'XCTest']
+  s.subspec 'Host' do |ss|
+    ss.ios.source_files = ['AutomationTools/Classes/HostApp/**/*']
   end
   
 end

--- a/Example/AutomationTools.xcodeproj/project.pbxproj
+++ b/Example/AutomationTools.xcodeproj/project.pbxproj
@@ -28,11 +28,12 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		100EDA43B637992DAA1AFF08 /* AutomationTools.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = AutomationTools.podspec; path = ../AutomationTools.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		31D7FE281E7A855E21C35AE2 /* Pods-AutomationTools_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AutomationTools_Example.release.xcconfig"; path = "Pods/Target Support Files/Pods-AutomationTools_Example/Pods-AutomationTools_Example.release.xcconfig"; sourceTree = "<group>"; };
 		4FAE45AA21CAD21F002779C7 /* AutomationTools_UITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AutomationTools_UITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		4FAE45AC21CAD21F002779C7 /* AutomationTools_UITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomationTools_UITests.swift; sourceTree = "<group>"; };
 		4FAE45AE21CAD220002779C7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		4FAF201A251C8223006FA42B /* AutomationTools-Core.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; name = "AutomationTools-Core.podspec"; path = "../AutomationTools-Core.podspec"; sourceTree = "<group>"; };
+		4FAF201B251C8223006FA42B /* AutomationTools-Host.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; name = "AutomationTools-Host.podspec"; path = "../AutomationTools-Host.podspec"; sourceTree = "<group>"; };
 		558CDECAC4DD81E0ECF7C5E3 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
 		607FACD01AFB9204008FA782 /* AutomationTools_Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AutomationTools_Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		607FACD41AFB9204008FA782 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -125,7 +126,8 @@
 		607FACF51AFB993E008FA782 /* Podspec Metadata */ = {
 			isa = PBXGroup;
 			children = (
-				100EDA43B637992DAA1AFF08 /* AutomationTools.podspec */,
+				4FAF201A251C8223006FA42B /* AutomationTools-Core.podspec */,
+				4FAF201B251C8223006FA42B /* AutomationTools-Host.podspec */,
 				DF6FE122AB76904C7D1D7CE4 /* README.md */,
 				558CDECAC4DD81E0ECF7C5E3 /* LICENSE */,
 			);

--- a/Example/AutomationTools/ViewController.swift
+++ b/Example/AutomationTools/ViewController.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import AutomationTools_Host
 
 class ViewController: UIViewController {
 

--- a/Example/AutomationTools_UITests/AutomationTools_UITests.swift
+++ b/Example/AutomationTools_UITests/AutomationTools_UITests.swift
@@ -7,6 +7,7 @@
 //
 
 import XCTest
+import AutomationTools_Core
 
 class AutomationTools_UITests: XCTestCase {
 

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -3,9 +3,9 @@ source 'https://github.com/CocoaPods/Specs.git'
 platform :ios, '11.0'
 
 target 'AutomationTools_Example' do
-  pod 'AutomationTools/HostApp', :path => '../'
+  pod 'AutomationTools-Host', :path => '../'
 end
 
 target 'AutomationTools_UITests' do
-  pod 'AutomationTools/Core', :path => '../'
+  pod 'AutomationTools-Core', :path => '../'
 end

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,18 +1,25 @@
 PODS:
-  - AutomationTools/Core (4.1.1)
-  - AutomationTools/HostApp (4.1.1)
+  - AutomationTools-Core (5.0.0):
+    - AutomationTools-Core/Host (= 5.0.0)
+  - AutomationTools-Core/Host (5.0.0)
+  - AutomationTools-Host (5.0.0):
+    - AutomationTools-Host/Host (= 5.0.0)
+  - AutomationTools-Host/Host (5.0.0)
 
 DEPENDENCIES:
-  - AutomationTools/Core (from `../`)
-  - AutomationTools/HostApp (from `../`)
+  - AutomationTools-Core (from `../`)
+  - AutomationTools-Host (from `../`)
 
 EXTERNAL SOURCES:
-  AutomationTools:
+  AutomationTools-Core:
+    :path: "../"
+  AutomationTools-Host:
     :path: "../"
 
 SPEC CHECKSUMS:
-  AutomationTools: 2c38a0dc2aacabd1ab7cfb668999065dd4739c2b
+  AutomationTools-Core: d7896d4e0c87f5f6df1f66b9a0a9510e1f0ec683
+  AutomationTools-Host: ac9b0cd8d7d6769d91e9c152c2a610583553df40
 
-PODFILE CHECKSUM: 92dc065c8304485c4f74b34f7e3f06210caf3167
+PODFILE CHECKSUM: 0fd856bc8278f852c3844cc09d6d4053099887f2
 
 COCOAPODS: 1.9.3

--- a/README.md
+++ b/README.md
@@ -1,16 +1,27 @@
 # AutomationTools
 
-[![CI Status](https://img.shields.io/travis/justeat/AutomationTools.svg?style=flat)](https://travis-ci.org/justeat/AutomationTools)
-[![Version](https://img.shields.io/cocoapods/v/AutomationTools.svg?style=flat)](https://cocoapods.org/pods/AutomationTools)
-[![License](https://img.shields.io/cocoapods/l/AutomationTools.svg?style=flat)](https://cocoapods.org/pods/AutomationTools)
-[![Platform](https://img.shields.io/cocoapods/p/AutomationTools.svg?style=flat)](https://cocoapods.org/pods/AutomationTools)
+### Core
+
+[![CI Status](https://img.shields.io/travis/justeat/AutomationTools-Core.svg?style=flat)](https://travis-ci.org/justeat/AutomationTools-Core)
+[![Version](https://img.shields.io/cocoapods/v/AutomationTools-Core.svg?style=flat)](https://cocoapods.org/pods/AutomationTools-Core)
+[![License](https://img.shields.io/cocoapods/l/AutomationTools-Core.svg?style=flat)](https://cocoapods.org/pods/AutomationTools-Core)
+[![Platform](https://img.shields.io/cocoapods/p/AutomationTools-Core.svg?style=flat)](https://cocoapods.org/pods/AutomationTools-Core)
+
+### Host
+
+[![CI Status](https://img.shields.io/travis/justeat/AutomationTools-Host.svg?style=flat)](https://travis-ci.org/justeat/AutomationTools-Host)
+[![Version](https://img.shields.io/cocoapods/v/AutomationTools-Host.svg?style=flat)](https://cocoapods.org/pods/AutomationTools-Host)
+[![License](https://img.shields.io/cocoapods/l/AutomationTools-Host.svg?style=flat)](https://cocoapods.org/pods/AutomationTools-Host)
+[![Platform](https://img.shields.io/cocoapods/p/AutomationTools-Host.svg?style=flat)](https://cocoapods.org/pods/AutomationTools-Host)
+
 
 ## About
+
 AutomationTools is a framework that helps you writing better and more maintainable UI tests. It allows launching the app, injecting flags to load the correct configuration and to automate repetitive actions (e.g. filling a basket, logging in a user etc.). The mechanism that is used for injecting state from a test case into the app under test is via the use of launch arguments and environment variables. The launch arguments are passed in to XCUIApplication’s launch method as an array of strings and the environment variables are passed as a dictionary. 
 
 Along with the state configuration functionality, AutomationTools also contains the most reused functionality that we have in our test suites. Things like Page Object base classes, sensible waiting methods and an extension for XCUIApplication all mean that our test suite is easy to maintain and has high readability, flexibility and code reuse.
 
-AutomationTools is sectioned in to Core and HostApp. Core consists of app state configuration, base classes and utilities. HostApp provides a bridge between the test case and the app by unwrapping the testcase injected flags.
+AutomationTools is composed of 2 pods: AutomationTools-Core and AutomationTools-Host. Core consists of app state configuration, base classes and utilities. Host provides a bridge between the test case and the app by unwrapping the testcase injected flags. The reason for using 2 separate podspecs instead of subspecs is to support Apple's new Build System. CocoaPods has a known [limitation](https://github.com/CocoaPods/CocoaPods/issues/8206) with naming the frameworks generated from subspecs.
 
 
 ### Core
@@ -57,7 +68,7 @@ func waitForElementToExist(element: XCUIElement, timeout: Double = 10)
 func waitForElementValueToExist(element: XCUIElement, valueString: String, timeout: Double = 10)
 ```
 
-### HostApp
+### Host
 
 The client should have a component able to inspect the flags in the `ProcessInfo`. This can be done via `AutomationBridge.swift`, which exposes the following methods:
 
@@ -85,7 +96,7 @@ Call the launchApp() method from the test case with relevant configuration to se
 
 ```swift
 import XCTest
-import AutomationTools
+import AutomationTools_Core
 
 class ExampleTestCases: ATTestCase {
     func testExample1() {
@@ -99,13 +110,13 @@ class ExampleTestCases: ATTestCase {
 } 
 ```
 
-#### HostApp
+#### Host
 
 Extend `AutomationBridge` to include methods required for configuring the environment.
 
 ```swift
 import Foundation
-import AutomationTools
+import AutomationTools_Host
 
 public extension AutomationBridge {
 
@@ -147,11 +158,11 @@ Include AutomationTools pod reference in the Checkout module's pod file
 
 ```
 target 'YourProject_MainTarget' do
-pod 'AutomationTools/HostApp', '1.0.0'
+pod 'AutomationTools-Host', '5.0.0'
 end
 
 target 'YourProject_UITestsTarget' do
-pod 'AutomationTools/Core', '1.0.0'
+pod 'AutomationTools-Core', '5.0.0'
 end
 ```
 


### PR DESCRIPTION
The reason for using 2 separate podspecs instead of subspecs is to support Apple's new Build System.
CocoaPods has a known [limitation](https://github.com/CocoaPods/CocoaPods/issues/8206) with naming the frameworks generated from subspecs.